### PR TITLE
Add FastAPI service with Celery-based processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,59 @@
 ## 🚀 Usage
 
 ```bash
-Obtain xls from your bank, put it in dir next to the script. Let it rip. 
+Obtain xls from your bank, put it in dir next to the script. Let it rip.
 python3 finance.py -f bank.xlsx --fx 117.5 --sqlite --debug
+```
+
+## 🖥️ API Service
+
+An asynchronous, multi-tenant HTTP API is available via FastAPI and Celery.
+
+### 1. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Start the services
+
+Open three terminals (or background the workers):
+
+```bash
+# API (http://127.0.0.1:8000/docs)
+uvicorn wallettaser.api:app --reload
+
+# Celery worker
+CELERY_BROKER_URL=redis://localhost:6379/0 \
+CELERY_RESULT_BACKEND=redis://localhost:6379/0 \
+celery -A wallettaser.celery_app.celery_app worker --loglevel=info
+
+# Redis (if you do not already have one)
+redis-server
+```
+
+Set `CELERY_TASK_ALWAYS_EAGER=1` when developing to execute jobs synchronously
+without the worker.
+
+### 3. Authenticate
+
+Use the bundled demo tenant (`demo` / `demo`) to obtain a bearer token:
+
+```bash
+curl -X POST http://127.0.0.1:8000/auth/token \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "demo", "password": "demo"}'
+```
+
+### 4. Upload statements
+
+```bash
+curl -X POST http://127.0.0.1:8000/statements/upload \
+  -H 'Authorization: Bearer <token>' \
+  -F 'file=@statement.xlsx'
+```
+
+Use the `/statements/{job_id}` endpoint to poll for completion and
+`/statements/{job_id}/result` to download the generated ZIP archive. Each user is
+isolated to their tenant: uploads, tags, and reports are stored in
+`data/<tenant-id>/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
 pandas
 matplotlib
 xlrd
+fastapi
+uvicorn
+python-multipart
+sqlalchemy
+celery
+redis

--- a/wallettaser/__init__.py
+++ b/wallettaser/__init__.py
@@ -1,0 +1,1 @@
+"""WalletTaser service package."""

--- a/wallettaser/api.py
+++ b/wallettaser/api.py
@@ -1,0 +1,89 @@
+"""FastAPI application exposing the WalletTaser pipeline."""
+from __future__ import annotations
+
+import shutil
+import uuid
+from pathlib import Path
+
+from fastapi import Depends, FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+
+from .auth import auth_router, ensure_default_user, get_current_user
+from .database import Base, engine, get_session
+from .models import Job, User
+from .pipeline import get_data_root
+from .tasks import process_statement_task
+
+app = FastAPI(title="WalletTaser API")
+app.include_router(auth_router)
+
+ensure_default_user()
+
+
+@app.on_event("startup")
+def _create_schema() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+@app.post("/statements/upload")
+def upload_statement(
+    file: UploadFile = File(...),
+    fx_rate: float | None = None,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="filename required")
+
+    job_id = uuid.uuid4().hex
+    tenant_id = user.tenant_id
+    job = Job(id=job_id, tenant_id=tenant_id, filename=file.filename, status="queued")
+    session.add(job)
+    session.commit()
+
+    tenant_root = get_data_root() / str(tenant_id) / "uploads" / job_id
+    tenant_root.mkdir(parents=True, exist_ok=True)
+    saved_path = tenant_root / file.filename
+    with saved_path.open("wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+    file.file.close()
+
+    process_statement_task.delay(job_id, tenant_id, str(saved_path), fx_rate)
+
+    return {"job_id": job_id, "status": job.status}
+
+
+@app.get("/statements/{job_id}")
+def get_job_status(
+    job_id: str,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    job = session.query(Job).filter(Job.id == job_id, Job.tenant_id == user.tenant_id).first()
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return {
+        "job_id": job.id,
+        "status": job.status,
+        "result_path": job.result_path,
+        "error": job.error,
+    }
+
+
+@app.get("/statements/{job_id}/result")
+def download_result(
+    job_id: str,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    job = session.query(Job).filter(Job.id == job_id, Job.tenant_id == user.tenant_id).first()
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.status != "completed" or not job.result_path:
+        raise HTTPException(status_code=400, detail="Job not completed")
+
+    archive_path = Path(job.result_path)
+    if not archive_path.exists():
+        raise HTTPException(status_code=404, detail="Result missing")
+    return FileResponse(archive_path, media_type="application/zip", filename=archive_path.name)

--- a/wallettaser/auth.py
+++ b/wallettaser/auth.py
@@ -1,0 +1,90 @@
+"""Authentication helpers and API routes."""
+from __future__ import annotations
+
+import secrets
+from hashlib import pbkdf2_hmac
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from .database import Base, engine, get_session, session_scope
+from .models import Tenant, User
+
+security = HTTPBearer()
+auth_router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+def _hash_password(password: str, salt: str) -> str:
+    return pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), 100000).hex()
+
+
+def create_user(session: Session, username: str, password: str, tenant: Tenant) -> User:
+    salt = secrets.token_hex(16)
+    password_hash = _hash_password(password, salt)
+    user = User(username=username, password_hash=password_hash, salt=salt, tenant=tenant)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def ensure_default_user() -> None:
+    Base.metadata.create_all(bind=engine)
+    with session_scope() as session:
+        tenant = session.query(Tenant).filter_by(name="default").first()
+        if tenant is None:
+            tenant = Tenant(name="default")
+            session.add(tenant)
+            session.flush()
+        user = session.query(User).filter_by(username="demo").first()
+        if user is None:
+            create_user(session, "demo", "demo", tenant)
+
+
+def authenticate(session: Session, username: str, password: str) -> User:
+    user = session.query(User).filter(User.username == username).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    expected = _hash_password(password, user.salt)
+    if secrets.compare_digest(expected, user.password_hash):
+        return user
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+
+def issue_token(session: Session, user: User) -> str:
+    token = secrets.token_hex(32)
+    user.api_token = token
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return token
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    session: Session = Depends(get_session),
+) -> User:
+    token = credentials.credentials
+    user = session.query(User).filter(User.api_token == token).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return user
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+@auth_router.post("/token", response_model=TokenResponse)
+def login(payload: LoginRequest, session: Session = Depends(get_session)) -> TokenResponse:
+    user = authenticate(session, payload.username, payload.password)
+    token = issue_token(session, user)
+    return TokenResponse(access_token=token)

--- a/wallettaser/celery_app.py
+++ b/wallettaser/celery_app.py
@@ -1,0 +1,19 @@
+"""Celery application instance for asynchronous work."""
+from __future__ import annotations
+
+import os
+
+from celery import Celery
+
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", CELERY_BROKER_URL)
+
+celery_app = Celery("wallettaser", broker=CELERY_BROKER_URL, backend=CELERY_RESULT_BACKEND, include=["wallettaser.tasks"])
+celery_app.conf.update(
+    task_serializer="json",
+    accept_content=["json"],
+    result_serializer="json",
+    timezone="UTC",
+    enable_utc=True,
+    task_always_eager=os.getenv("CELERY_TASK_ALWAYS_EAGER", "false").lower() in {"1", "true", "yes"},
+)

--- a/wallettaser/database.py
+++ b/wallettaser/database.py
@@ -1,0 +1,38 @@
+"""Database helpers for the WalletTaser service."""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./wallettaser.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_session():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@contextmanager
+def session_scope():
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/wallettaser/models.py
+++ b/wallettaser/models.py
@@ -1,0 +1,44 @@
+"""SQLAlchemy ORM models."""
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class Tenant(Base):
+    __tablename__ = "tenants"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    salt = Column(String, nullable=False)
+    api_token = Column(String, unique=True, nullable=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"), nullable=False)
+
+    tenant = relationship("Tenant", backref="users")
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id = Column(String, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"), nullable=False)
+    filename = Column(String, nullable=False)
+    status = Column(String, nullable=False, default="queued")
+    result_path = Column(String, nullable=True)
+    report_directory = Column(String, nullable=True)
+    error = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    tenant = relationship("Tenant", backref="jobs")

--- a/wallettaser/pipeline.py
+++ b/wallettaser/pipeline.py
@@ -1,0 +1,72 @@
+"""Tenant-aware wrappers around the reporting pipeline."""
+from __future__ import annotations
+
+import os
+import zipfile
+from pathlib import Path
+from typing import TypedDict
+
+from .reporting import ReportSummary, generate_report
+
+DATA_ROOT_ENV = "WALLETTASER_DATA_ROOT"
+DEFAULT_DATA_ROOT = Path("data")
+
+
+class PipelineResult(TypedDict):
+    report_directory: str
+    archive_path: str
+    summary: ReportSummary
+
+
+def get_data_root() -> Path:
+    """Return the base directory that stores tenant specific data."""
+    root = Path(os.getenv(DATA_ROOT_ENV, DEFAULT_DATA_ROOT))
+    if not root.is_absolute():
+        root = Path.cwd() / root
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def tenant_root(tenant_id: int | str) -> Path:
+    base = get_data_root()
+    path = base / str(tenant_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def process_statement(
+    *,
+    tenant_id: int | str,
+    job_id: str,
+    statement_path: Path,
+    fx_rate: float | None = None,
+) -> PipelineResult:
+    """Run the reporting pipeline for ``statement_path`` and return artefacts."""
+    tenant_dir = tenant_root(tenant_id)
+    reports_dir = tenant_dir / "reports" / job_id
+    uploads_dir = tenant_dir / "uploads"
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+
+    tag_file = tenant_dir / "vendor_tags.csv"
+
+    report_summary = generate_report(
+        statement_path,
+        reports_dir,
+        fx_rate=fx_rate,
+        tag_file=tag_file,
+    )
+
+    archive_dir = tenant_dir / "archives"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = archive_dir / f"{job_id}.zip"
+
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for path in reports_dir.rglob("*"):
+            if path.is_file():
+                archive.write(path, path.relative_to(reports_dir))
+
+    return PipelineResult(
+        report_directory=str(reports_dir),
+        archive_path=str(archive_path),
+        summary=report_summary,
+    )

--- a/wallettaser/reporting.py
+++ b/wallettaser/reporting.py
@@ -1,0 +1,299 @@
+"""Reusable reporting pipeline extracted from :mod:`finance`."""
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import timedelta
+from itertools import cycle
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from finance import DEF_FX, fmt, load_clean, summary
+
+
+@dataclass
+class ReportSummary:
+    months_observed: int
+    average_savings: float
+    average_income: float
+    average_spend: float
+    average_stock_investment: float
+    projected_net: list[float]
+    projected_savings: list[float]
+    last_week_spend: float
+    previous_week_spend: float
+    delta_week_spend: float
+    vampires: list[str]
+    fx_rate: float
+
+
+def _load_tags(tag_file: Path) -> dict[str, str]:
+    if not tag_file.exists():
+        return {}
+    with tag_file.open(newline="") as handle:
+        return {row["VENDOR"]: row["CLASS"] for row in csv.DictReader(handle)}
+
+
+def _needs_wants(row: pd.Series, tags: dict[str, str]) -> str:
+    if row["CATEGORY"] in ("SAVINGS", "STOCKS/CRYPTO"):
+        return "TRANSFER"
+    vendor_tag = tags.get(row["VENDOR"])
+    if vendor_tag:
+        return vendor_tag
+    # default to WANTS to avoid silently promoting unknown vendors
+    return "WANTS"
+
+
+def _plot_totals(folder: Path, months: int, income: float, spend: float, savings: float, stocks: float) -> None:
+    labels = ["Spend", "Save", "Stocks", "Income"]
+    values = [abs(spend) * months, savings * months, stocks * months, income * months]
+    plt.figure(figsize=(8, 4))
+    bars = plt.bar(labels, values, color=["#e74c3c", "#27ae60", "#8e44ad", "#3498db"])
+    for bar, value in zip(bars, values):
+        plt.text(bar.get_x() + bar.get_width() / 2, value, fmt(value),
+                 ha="center", va="bottom", fontsize=9)
+    plt.title("Totals by Category")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / "totals.png")
+    plt.close()
+
+
+TOP_COLORS = cycle(["#e74c3c", "#f1c40f", "#27ae60"])
+
+
+def _plot_vendors(folder: Path, df: pd.DataFrame) -> None:
+    top = (
+        df[df.Iznos < 0]
+        .groupby("VENDOR")["Iznos"]
+        .sum()
+        .abs()
+        .sort_values(ascending=False)
+        .head(10)
+    )
+    colors = [next(TOP_COLORS) if i < 3 else "#2980b9" for i in range(len(top))]
+    plt.figure(figsize=(10, 6))
+    bars = plt.bar(top.index, top.values, color=colors)
+    for bar, value in zip(bars, top.values):
+        plt.text(bar.get_x() + bar.get_width() / 2, value, fmt(value),
+                 ha="center", va="bottom", fontsize=9)
+    plt.title("Top Vendor Spend")
+    plt.ylabel("RSD")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig(folder / "vendors_top.png")
+    plt.close()
+
+
+def _plot_weekday(folder: Path, df: pd.DataFrame) -> None:
+    wk = df[df.Iznos < 0].groupby("DAY")["Iznos"].sum()
+    plt.figure(figsize=(8, 4))
+    wk.plot(kind="bar", color="#c0392b")
+    plt.title("Spending by Weekday")
+    plt.ylabel("RSD")
+    plt.xticks(range(7), ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"])
+    plt.tight_layout()
+    plt.savefig(folder / "weekday_spend.png")
+    plt.close()
+
+
+def _plot_hourly(folder: Path, df: pd.DataFrame) -> None:
+    hr = df[df.Iznos < 0].groupby("HOUR")["Iznos"].sum()
+    if hr.sum() == 0 or hr.nunique() <= 1:
+        return
+    hr = hr.reindex(range(24), fill_value=0)
+    plt.figure(figsize=(14, 4))
+    hr.plot(kind="bar", color="#9b59b6")
+    plt.grid(axis="y", alpha=0.3)
+    plt.title("Spending by Hour (0-23)")
+    plt.xlabel("Hour")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / "hourly_spend.png")
+    plt.close()
+
+
+def _plot_monthly_trends(folder: Path, df: pd.DataFrame) -> None:
+    monthly = (
+        df.groupby(["YEAR_MONTH", "ADV_CAT"])["Iznos"]
+        .sum()
+        .unstack()
+        .fillna(0)
+    )
+    monthly.plot(kind="bar", stacked=True, figsize=(12, 6))
+    plt.title("Monthly Cash-flow by Advanced Category")
+    plt.ylabel("RSD")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig(folder / "monthly_trends.png")
+    plt.close()
+
+
+def _plot_rolling(folder: Path, df: pd.DataFrame) -> None:
+    daily = (
+        df[df.Iznos < 0]
+        .set_index("Datum")
+        .resample("D")["Iznos"]
+        .sum()
+        .abs()
+    )
+    window = 30 if len(daily) >= 30 else 7
+    daily.rolling(window).sum().plot(figsize=(12, 5))
+    plt.title(f"{window}-Day Rolling Spend")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / f"rolling{window}_spend.png")
+    plt.close()
+
+
+def _plot_monthly_net(folder: Path, df: pd.DataFrame) -> None:
+    net_monthly = df.groupby("YEAR_MONTH")["Iznos"].sum()
+    net_monthly.plot(marker="o", figsize=(10, 4))
+    plt.axhline(0, color="gray", ls="--")
+    plt.title("Monthly Net Δ")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / "monthly_net.png")
+    plt.close()
+
+
+def _plot_needs_wants(folder: Path, df: pd.DataFrame) -> None:
+    summary_df = (
+        df[(df.Iznos < 0) & (df.NEEDS_WANTS != "TRANSFER")]
+        .groupby("NEEDS_WANTS")["Iznos"]
+        .sum()
+        .abs()
+    )
+    summary_df = summary_df.reindex(["NEEDS", "WANTS"]).fillna(0)
+    plt.figure(figsize=(7, 5))
+    bars = plt.bar(summary_df.index, summary_df.values, color=["#2ecc71", "#e67e22"])
+    for bar, value in zip(bars, summary_df.values):
+        plt.text(bar.get_x() + bar.get_width() / 2, value, fmt(value),
+                 ha="center", va="bottom", fontsize=10)
+    plt.title("NEEDS vs WANTS")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / "needs_wants.png")
+    plt.close()
+
+
+def _plot_projected_net(folder: Path, net_projection: Iterable[float]) -> None:
+    xs = list(range(len(net_projection)))
+    ys = list(net_projection)
+    plt.figure(figsize=(10, 5))
+    plt.plot(xs, ys, marker="o", color="#1abc9c")
+    plt.title("Projected Net Worth")
+    plt.xlabel("Months")
+    plt.ylabel("RSD")
+    plt.grid(alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(folder / "projected_net.png")
+    plt.close()
+
+
+def _plot_projected_savings(folder: Path, savings_projection: Iterable[float]) -> None:
+    xs = list(range(1, len(savings_projection) + 1))
+    plt.figure(figsize=(10, 5))
+    plt.plot(xs, savings_projection, marker="o", color="#e67e22")
+    plt.title("Projected Savings Only (12 mo)")
+    plt.xlabel("Months")
+    plt.ylabel("RSD")
+    plt.grid(alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(folder / "projected_savings.png")
+    plt.close()
+
+
+def generate_report(
+    statement_path: Path,
+    output_folder: Path,
+    *,
+    fx_rate: float | None = None,
+    tag_file: Path | None = None,
+    sqlite_path: Path | None = None,
+    debug: bool = False,
+) -> ReportSummary:
+    """Run the finance pipeline and persist the generated artefacts."""
+    output_folder.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.DEBUG if debug else logging.INFO,
+        format="[%(levelname)s] %(message)s",
+    )
+
+    fx_rate = fx_rate or DEF_FX
+    tag_file = tag_file or Path("vendor_tags.csv")
+
+    tags = _load_tags(tag_file)
+
+    df = load_clean(str(statement_path))
+    df["NEEDS_WANTS"] = df.apply(lambda row: _needs_wants(row, tags), axis=1)
+
+    months, net_projection, savings_projection, avg_savings, avg_income, avg_spend, avg_stocks = summary(df)
+
+    # plotting
+    _plot_totals(output_folder, months, avg_income, avg_spend, avg_savings, avg_stocks)
+    _plot_vendors(output_folder, df)
+    _plot_needs_wants(output_folder, df)
+    _plot_weekday(output_folder, df)
+    _plot_hourly(output_folder, df)
+    _plot_monthly_trends(output_folder, df)
+    _plot_rolling(output_folder, df)
+    _plot_monthly_net(output_folder, df)
+    _plot_projected_net(output_folder, net_projection)
+    _plot_projected_savings(output_folder, savings_projection)
+
+    enriched_path = output_folder / "full_enriched_dataset.csv"
+    df.to_csv(enriched_path, index=False)
+
+    if sqlite_path is not None:
+        with sqlite3.connect(sqlite_path) as connection:
+            df.to_sql("tx", connection, if_exists="append", index=False)
+
+    today = pd.Timestamp.today().normalize()
+    last_week = abs(df[(df.Datum >= today - timedelta(days=7)) & (df.Iznos < 0)]["Iznos"].sum())
+    previous_week = abs(
+        df[
+            (df.Datum >= today - timedelta(days=14))
+            & (df.Datum < today - timedelta(days=7))
+            & (df.Iznos < 0)
+        ]["Iznos"].sum()
+    )
+    delta_week = last_week - previous_week
+    total_spend = df[df.Iznos < 0]["Iznos"].abs().sum() or 1
+    vampires = (
+        df[df.Iznos < 0]
+        .groupby("VENDOR")["Iznos"]
+        .sum()
+        .abs()
+        .divide(total_spend)
+        .loc[lambda series: series > 0.05]
+        .index
+        .tolist()
+    )
+
+    summary_payload = ReportSummary(
+        months_observed=months,
+        average_savings=avg_savings,
+        average_income=avg_income,
+        average_spend=avg_spend,
+        average_stock_investment=avg_stocks,
+        projected_net=list(net_projection),
+        projected_savings=list(savings_projection),
+        last_week_spend=last_week,
+        previous_week_spend=previous_week,
+        delta_week_spend=delta_week,
+        vampires=vampires,
+        fx_rate=fx_rate,
+    )
+
+    metadata_path = output_folder / "metadata.json"
+    with metadata_path.open("w", encoding="utf-8") as handle:
+        json.dump(summary_payload.__dict__, handle, indent=2)
+
+    return summary_payload

--- a/wallettaser/tasks.py
+++ b/wallettaser/tasks.py
@@ -1,0 +1,54 @@
+"""Celery task definitions."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from .celery_app import celery_app
+from .database import SessionLocal
+from .models import Job
+from .pipeline import process_statement
+
+
+@celery_app.task(bind=True)
+def process_statement_task(self, job_id: str, tenant_id: int, statement_path: str, fx_rate: float | None = None) -> dict:
+    logging.info("Starting processing for job %s", job_id)
+    session: Session = SessionLocal()
+    try:
+        job = session.query(Job).filter(Job.id == job_id, Job.tenant_id == tenant_id).first()
+        if job is None:
+            logging.error("Job %s not found", job_id)
+            return {"status": "missing"}
+        job.status = "processing"
+        session.commit()
+
+        result = process_statement(
+            tenant_id=tenant_id,
+            job_id=job_id,
+            statement_path=Path(statement_path),
+            fx_rate=fx_rate,
+        )
+
+        job.status = "completed"
+        job.result_path = result["archive_path"]
+        job.report_directory = result["report_directory"]
+        session.commit()
+        logging.info("Job %s completed", job_id)
+        return {
+            "status": job.status,
+            "archive_path": job.result_path,
+            "report_directory": job.report_directory,
+        }
+    except Exception as exc:  # noqa: BLE001
+        session.rollback()
+        logging.exception("Job %s failed", job_id)
+        job = session.query(Job).filter(Job.id == job_id).first()
+        if job:
+            job.status = "failed"
+            job.error = str(exc)
+            session.commit()
+        raise
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- add a FastAPI application that exposes authenticated endpoints for uploading statements, polling job status, and downloading results
- integrate Celery workers with a tenant-aware pipeline so uploads trigger asynchronous report generation
- introduce SQLAlchemy models, authentication helpers, and documentation for running the new API stack

## Testing
- python -m compileall wallettaser

------
https://chatgpt.com/codex/tasks/task_e_68caa6c6f4288325b8df5b42d2e282f6