### PR TITLE
Refactor into package facade and add tests

### DIFF
--- a/finance.py
+++ b/finance.py
@@ -1,310 +1,159 @@
 #!/usr/bin/env python3
-# ─────────────────────────────────────────────────────────────
-#  #  (full report  + 12-month savings projection)
-# ─────────────────────────────────────────────────────────────
-"""
-$ python3 finance.py
-$ python3 finance.py -f bank.xlsx --fx 118 --sqlite --debug
-Creates ./finance_report_<timestamp>/  with:
-  totals.png, vendors_top.png, needs_wants.png,
-  weekday_spend.png, hourly_spend.png (if data present),
-  monthly_trends.png, rolling30_spend.png (or rolling7*),
-  monthly_net.png, projected_net.png,
-  projected_savings.png  ⟵ NEW
-  full_enriched_dataset.csv  (+ transactions.db if --sqlite)
-"""
+"""Wallet Taser CLI wrapper."""
 from __future__ import annotations
-import argparse, csv, glob, logging, os, re, sqlite3, sys, textwrap
-from datetime import datetime, timedelta
-from itertools import cycle
 
-import matplotlib.pyplot as plt
+import argparse
+import csv
+import glob
+import logging
+import os
+import sqlite3
+import textwrap
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict
+
 import pandas as pd
 
-TAG_FILE = 'vendor_tags.csv'           # persistent NEEDS/WANTS map
-DEF_FX   = 117.0                       # default RSD → EUR
+from wallettaser import ProcessedStatement, process_statement
+from wallettaser.categorization import apply_needs_wants
+
+TAG_FILE = "vendor_tags.csv"
+DEF_FX = 117.0
+
+fmt = lambda value: f"{value:,.2f}"
+latest_xls = lambda: sorted(glob.glob("*.xls*"), key=os.path.getmtime, reverse=True)[0]
+
 
 # ─────────────────── logging ────────────────────
 def setup_logging(debug: bool) -> None:
-    logging.basicConfig(
-        level=logging.DEBUG if debug else logging.INFO,
-        format='[%(levelname)s] %(message)s'
-    )
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO, format="[%(levelname)s] %(message)s")
 
-# ─────────────────── helpers ─────────────────────
-fmt  = lambda x: f'{x:,.2f}'
-latest_xls = lambda: sorted(glob.glob('*.xls*'),
-                            key=os.path.getmtime, reverse=True)[0]
 
-# ─────────── vendor  patterns ──────────
-PATTERNS = {
-    'MAXI':['maxi'], 'TIDAL':['tidal'],
-    'CAR GO':['car go','cargo'], 'APOTEKA':['apoteka'], 'LIDL':['lidl'],
-    'EBAY':['ebay'], 'ALIEXPRESS':['aliexpress','ali express','ali'],
-    'GO TECH':['go technologies'],
-    'PAYPAL':['paypal'], 'WOLT':['wolt'], 'DEXPRESS':['dexpress'],
-}
-ADVANCED_PATTERNS = {
-    'FOOD':['lidl','maxi','idea','tempo','shop&go'],
-    'TRANSPORT':['car go','naxis','busplus'],
-    'EDUCATION':['udemy','tryhackme','coursera','book'],
-    'MEDICAL':['apoteka','pharmacy','dr'],
-    'ENTERTAINMENT':['netflix','tidal','youtube','spotify'],
-}
-try:
-    with open(TAG_FILE, newline='') as f:
-        TAGS = {r['VENDOR']: r['CLASS'] for r in csv.DictReader(f)}
-except FileNotFoundError: TAGS = {}
+# ─────────────────── tagging helpers ────────────────────
+def load_vendor_tags(path: str = TAG_FILE) -> Dict[str, str]:
+    try:
+        with open(path, newline="") as handle:
+            return {row["VENDOR"]: row["CLASS"] for row in csv.DictReader(handle)}
+    except FileNotFoundError:
+        return {}
 
-def vendor(opis:str)->str:
-    low=opis.lower()
-    for v,keys in PATTERNS.items():
-        if any(k in low for k in keys): return v
-    m=re.search(r'[A-Za-z]{4,}',opis)
-    return m.group(0).upper() if m else 'OTHER'
 
-# ─── categorisation ───
-def _base_cat(r:pd.Series)->str:
-    o,t,v=r['Opis'].lower(), r['Tip'].lower(), r['Iznos']
-    if 'kupovina eur' in o:                                 return 'SAVINGS'
-    if any(w in o for w in ('zarada','prilivi')) or 'uplata' in t:  return 'INCOME'
-    if any(w in o for w in ('xtb','binance','bifinity','bit')):     return 'STOCKS/CRYPTO'
-    if any(w in o for w in ('bankomat','isplata gotovine')):        return 'ATM_CASHOUT'
-    if v>0: return 'INCOME'
-    return 'SPENDING'
+def save_vendor_tags(tags: Dict[str, str], path: str = TAG_FILE) -> None:
+    with open(path, "w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["VENDOR", "CLASS"])
+        writer.writeheader()
+        for vendor, klass in sorted(tags.items()):
+            writer.writerow({"VENDOR": vendor, "CLASS": klass})
 
-def _adv_cat(r:pd.Series)->str:
-    l=r['Opis'].lower()
-    for c,keys in ADVANCED_PATTERNS.items():
-        if any(k in l for k in keys): return c
-    return _base_cat(r)
 
-# ─── load & clean ───
-def load_clean(path:str)->pd.DataFrame:
-    raw=pd.read_excel(path,header=None,dtype=str)
-    hdr=next(i for i in range(30) if sum(
-        any(k in str(c).lower() for k in ('datum','tip','opis','iznos'))
-        for c in raw.iloc[i])>=3)
-    df=pd.read_excel(path,header=hdr,dtype=str)
-    ren={}
-    for c in df.columns:
-        l=str(c).lower()
-        if 'datum' in l: ren[c]='Datum'
-        elif 'tip' in l: ren[c]='Tip'
-        elif any(w in l for w in ('opis','naziv','det')): ren[c]='Opis'
-        elif any(w in l for w in ('iznos','amount','suma')): ren[c]='Iznos'
-    df=df.rename(columns=ren)[['Datum','Tip','Opis','Iznos']].dropna()
-    df['Datum']=pd.to_datetime(df['Datum'],dayfirst=True,errors='coerce')
-    df=df[df['Datum'].notna()].copy()
-    df['Iznos']=(df['Iznos'].str.replace(r'[^0-9,.\-]','',regex=True)
-                             .str.replace('.','',regex=False)
-                             .str.replace(',', '.',regex=False)
-                             .astype(float))
-    df['CATEGORY']=df.apply(_base_cat,axis=1)
-    df.loc[df.CATEGORY=='SAVINGS','Iznos']=df.loc[df.CATEGORY=='SAVINGS','Iznos'].abs()
-    df['VENDOR'] = df['Opis'].apply(vendor)
-    df['ADV_CAT']=df.apply(_adv_cat,axis=1)
-    df['MONTH']=df.Datum.dt.to_period('M')
-    df['YEAR_MONTH']=df['MONTH']; df['DAY']=df.Datum.dt.dayofweek
-    df['HOUR']=df.Datum.dt.hour
-    return df
-
-# ─── NEEDS/WANTS tagging ───
-def tag_new_vendors(df:pd.DataFrame)->None:
-    global TAGS
-    freq=(df['VENDOR'].value_counts()
-          .loc[lambda s:s>=3].index.difference(TAGS))
+def tag_new_vendors(df: pd.DataFrame, tags: Dict[str, str]) -> bool:
+    updated = False
+    freq = df["VENDOR"].value_counts().loc[lambda series: series >= 3].index.difference(tags)
     if not freq.empty:
-        print('\n► Tag vendors: NEEDS (n) / WANTS (w)')
-    for v in freq:
+        print("\n► Tag vendors: NEEDS (n) / WANTS (w)")
+    for vendor in freq:
         while True:
-            ans=input(f'  {v}: n/w? ').strip().lower()
-            if ans in ('n','w'):
-                TAGS[v]='NEEDS' if ans=='n' else 'WANTS'; break
-    if freq.any():
-        with open(TAG_FILE,'w',newline='') as f:
-            w=csv.DictWriter(f,fieldnames=['VENDOR','CLASS'])
-            w.writeheader(); [w.writerow({'VENDOR':k,'CLASS':v}) for k,v in TAGS.items()]
+            answer = input(f"  {vendor}: n/w? ").strip().lower()
+            if answer in ("n", "w"):
+                tags[vendor] = "NEEDS" if answer == "n" else "WANTS"
+                updated = True
+                break
+    return updated
 
-def needs_wants(r:pd.Series)->str:
-    if r['CATEGORY'] in ('SAVINGS','STOCKS/CRYPTO'): return 'TRANSFER'
-    return TAGS.get(r['VENDOR'],'WANTS')
 
-# ─── core math ───
-def project_savings(avg_save:float, months:int=12)->list[float]:
-    return [round(avg_save*m,2) for m in range(1,months+1)]
-
-def summary(df:pd.DataFrame):
-    m=df['MONTH'].nunique() or 1
-    s=lambda c:df[df.CATEGORY==c]['Iznos'].sum()
-    income, spend, saves, stocks = s('INCOME'), s('SPENDING'), s('SAVINGS'), abs(s('STOCKS/CRYPTO'))
-    ai, asp, asv, ast = income/m, spend/m, saves/m, stocks/m
-    net=[0]; [net.append(net[-1]+ai-abs(asp)+asv+ast) for _ in range(12)]
-    save_proj=project_savings(asv,12)
-    return m, net, save_proj, asv, ai, asp, ast
-
-# ─── plotting ───
-def safe(fn):                # decorator
-    def wrap(*a,**k):
-        try:fn(*a,**k)
-        except Exception as e: logging.warning('%s failed: %s',fn.__name__,e)
-    return wrap
-
-@safe
-def plot_totals(folder,m,ai,asp,asv,ast):
-    labels=['Spend','Save','Stocks','Income']
-    vals=[abs(asp)*m,asv*m,ast*m,ai*m]
-    plt.figure(figsize=(8,4))
-    bars=plt.bar(labels,vals,color=['#e74c3c','#27ae60','#8e44ad','#3498db'])
-    for b,v in zip(bars,vals): plt.text(b.get_x()+b.get_width()/2,v,fmt(v),
-                                        ha='center',va='bottom',fontsize=9)
-    plt.title('Totals by Category'); plt.ylabel('RSD')
-    plt.tight_layout(); plt.savefig(f'{folder}/totals.png'); plt.close()
-
-TOP_COLORS=cycle(['#e74c3c','#f1c40f','#27ae60'])
-@safe
-def plot_vendors(folder,df):
-    top=(df[df.Iznos<0].groupby('VENDOR')['Iznos']
-         .sum().abs().sort_values(ascending=False).head(10))
-    colors=[next(TOP_COLORS) if i<3 else '#2980b9' for i in range(len(top))]
-    plt.figure(figsize=(10,6))
-    bars=plt.bar(top.index,top.values,color=colors)
-    for b,v in zip(bars,top.values):
-        plt.text(b.get_x()+b.get_width()/2,v,fmt(v),ha='center',va='bottom',fontsize=9)
-    plt.title('Top Vendor Spend'); plt.ylabel('RSD'); plt.xticks(rotation=45)
-    plt.tight_layout(); plt.savefig(f'{folder}/vendors_top.png'); plt.close()
-
-@safe
-def plot_weekday(folder,df):
-    wk=df[df.Iznos<0].groupby('DAY')['Iznos'].sum()
-    plt.figure(figsize=(8,4)); wk.plot(kind='bar',color='#c0392b')
-    plt.title('Spending by Weekday'); plt.ylabel('RSD')
-    plt.xticks(range(7),['Mon','Tue','Wed','Thu','Fri','Sat','Sun'])
-    plt.tight_layout(); plt.savefig(f'{folder}/weekday_spend.png'); plt.close()
-
-@safe
-def plot_hourly(folder,df):
-    hr=df[df.Iznos<0].groupby('HOUR')['Iznos'].sum()
-    if hr.sum()==0 or hr.nunique()<=1: return
-    hr=hr.reindex(range(24),fill_value=0)
-    plt.figure(figsize=(14,4)); hr.plot(kind='bar',color='#9b59b6')
-    plt.grid(axis='y',alpha=.3); plt.title('Spending by Hour (0-23)')
-    plt.xlabel('Hour'); plt.ylabel('RSD')
-    plt.tight_layout(); plt.savefig(f'{folder}/hourly_spend.png'); plt.close()
-
-@safe
-def plot_monthly_trends(folder,df):
-    m=(df.groupby(['YEAR_MONTH','ADV_CAT'])['Iznos']
-         .sum().unstack().fillna(0))
-    m.plot(kind='bar',stacked=True,figsize=(12,6))
-    plt.title('Monthly Cash-flow by Advanced Category'); plt.ylabel('RSD')
-    plt.xticks(rotation=45)
-    plt.tight_layout(); plt.savefig(f'{folder}/monthly_trends.png'); plt.close()
-
-@safe
-def plot_rolling(folder,df):
-    daily=(df[df.Iznos<0]
-             .set_index('Datum').resample('D')['Iznos']
-             .sum().abs())
-    win=30 if len(daily)>=30 else 7
-    daily.rolling(win).sum().plot(figsize=(12,5))
-    plt.title(f'{win}-Day Rolling Spend'); plt.ylabel('RSD')
-    plt.tight_layout(); plt.savefig(f'{folder}/rolling{win}_spend.png'); plt.close()
-
-@safe
-def plot_monthly_net(folder,df):
-    netm=df.groupby('YEAR_MONTH')['Iznos'].sum()
-    netm.plot(marker='o',figsize=(10,4))
-    plt.axhline(0,color='gray',ls='--')
-    plt.title('Monthly Net Δ'); plt.ylabel('RSD')
-    plt.tight_layout(); plt.savefig(f'{folder}/monthly_net.png'); plt.close()
-
-@safe
-def plot_needs_wants(folder,df):
-    s=(df[(df.Iznos<0)&(df.NEEDS_WANTS!='TRANSFER')]
-         .groupby('NEEDS_WANTS')['Iznos'].sum().abs())
-    s=s.reindex(['NEEDS','WANTS']).fillna(0)
-    plt.figure(figsize=(7,5))
-    bars=plt.bar(s.index,s.values,color=['#2ecc71','#e67e22'])
-    for b,v in zip(bars,s.values):
-        plt.text(b.get_x()+b.get_width()/2,v,fmt(v),ha='center',va='bottom',fontsize=10)
-    plt.title('NEEDS vs WANTS'); plt.ylabel('RSD')
-    plt.tight_layout(); plt.savefig(f'{folder}/needs_wants.png'); plt.close()
-
-@safe
-def plot_projected_net(folder,net):
-    xs=list(range(len(net))); ys=net
-    plt.figure(figsize=(10,5))
-    plt.plot(xs,ys,marker='o',color='#1abc9c')
-    plt.title('Projected Net Worth'); plt.xlabel('Months'); plt.ylabel('RSD')
-    plt.grid(alpha=.3)
-    plt.tight_layout(); plt.savefig(f'{folder}/projected_net.png'); plt.close()
-
-@safe
-def plot_projected_savings(folder,save_proj):
-    xs=list(range(1,len(save_proj)+1))
-    plt.figure(figsize=(10,5))
-    plt.plot(xs,save_proj,marker='o',color='#e67e22')
-    plt.title('Projected Savings Only (12 mo)')
-    plt.xlabel('Months'); plt.ylabel('RSD')
-    plt.grid(alpha=.3)
-    plt.tight_layout(); plt.savefig(f'{folder}/projected_savings.png'); plt.close()
-
-# ─── CLI ───
-P=argparse.ArgumentParser(
-    description='Balkan Schizo Finance – Wallet Taser',
+# ─────────────────── CLI ────────────────────
+PARSER = argparse.ArgumentParser(
+    description="Balkan Schizo Finance – Wallet Taser",
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=textwrap.dedent('''
+    epilog=textwrap.dedent(
+        """
       Examples:
         python3 finance.py
-        python3 finance.py -f bank.xlsx --fx 118 --sqlite --debug'''))
-P.add_argument('-f','--file',help='bank statement (.xls/.xlsx)')
-P.add_argument('--fx',type=float,help=f'RSD→EUR (default {DEF_FX})')
-P.add_argument('--sqlite',action='store_true',help='append rows to transactions.db')
-P.add_argument('--debug',action='store_true',help='verbose logging')
+        python3 finance.py -f bank.xlsx --fx 118 --sqlite --debug
+        """
+    ),
+)
+PARSER.add_argument("-f", "--file", help="bank statement (.xls/.xlsx)")
+PARSER.add_argument("--fx", type=float, help=f"RSD→EUR (default {DEF_FX})")
+PARSER.add_argument("--sqlite", action="store_true", help="append rows to transactions.db")
+PARSER.add_argument("--debug", action="store_true", help="verbose logging")
 
-# ─── main ───
-def main():
-    a=P.parse_args(); setup_logging(a.debug)
-    path=a.file or (logging.info('Using statement %s',latest_xls()) or latest_xls())
-    fx=a.fx or float(input(f'RSD→EUR rate (Enter for {DEF_FX}): ') or DEF_FX)
 
-    df=load_clean(path)
-    tag_new_vendors(df)
-    df['NEEDS_WANTS']=df.apply(needs_wants,axis=1)
+# ─────────────────── orchestration ────────────────────
+def ensure_needs_wants(result: ProcessedStatement, tags: Dict[str, str]) -> None:
+    apply_needs_wants(result.dataframe, tags, inplace=True)
 
-    months, net, save_proj, asv, ai, asp, ast = summary(df)
-    folder=f'finance_report_{datetime.now():%Y%m%d_%H%M%S}'; os.makedirs(folder,exist_ok=True)
 
-    # plots
-    plot_totals(folder,months,ai,asp,asv,ast)
-    plot_vendors(folder,df); plot_needs_wants(folder,df); plot_weekday(folder,df)
-    plot_hourly(folder,df); plot_monthly_trends(folder,df)
-    plot_rolling(folder,df); plot_monthly_net(folder,df)
-    plot_projected_net(folder,net); plot_projected_savings(folder,save_proj)
+def render_reports(result: ProcessedStatement, folder: Path) -> None:
+    for spec in result.charts:
+        spec.render(folder, result.dataframe, result.summary)
 
-    df.to_csv(f'{folder}/full_enriched_dataset.csv',index=False)
-    if a.sqlite:
-        with sqlite3.connect('transactions.db') as con:
-            df.to_sql('tx',con,if_exists='append',index=False)
 
-    # console summary
-    today=pd.Timestamp.today().normalize()
-    last7=abs(df[(df.Datum>=today-timedelta(days=7)) & (df.Iznos<0)]['Iznos'].sum())
-    prev7=abs(df[(df.Datum>=today-timedelta(days=14)) & (df.Datum<today-timedelta(days=7)) & (df.Iznos<0)]['Iznos'].sum())
-    delta=last7-prev7
-    total_spend=df[df.Iznos<0]['Iznos'].abs().sum()
-    vampires=(df[df.Iznos<0].groupby('VENDOR')['Iznos'].sum().abs()/total_spend)\
-             .loc[lambda s:s>0.05].index.tolist()
+def main() -> None:
+    args = PARSER.parse_args()
+    setup_logging(args.debug)
 
-    print(f'\nMonths: {months} | Avg save: {fmt(asv)} RSD'
-          f' | Net 12 mo: {fmt(net[-1])} RSD ({fmt(net[-1]/fx)} €)')
-    print(f'Last 7-day spend: {fmt(last7)} RSD (Δ {fmt(delta)} vs prev 7 d)')
-    if vampires: print('Consider cutting:', ', '.join(vampires))
-    print('Projected pure savings (12 mo):')
-    for i,v in enumerate(save_proj,1):
-        print(f'  +{i:02d} mo → {fmt(v)} RSD ({fmt(v/fx)} €)')
-    print('Charts + CSV saved →', folder)
+    if args.file:
+        path = args.file
+    else:
+        latest = latest_xls()
+        logging.info("Using statement %s", latest)
+        path = latest
 
-if __name__ == '__main__':
+    fx = args.fx or float(input(f"RSD→EUR rate (Enter for {DEF_FX}): ") or DEF_FX)
+
+    result = process_statement(path, fx_rate=fx)
+    tags = load_vendor_tags()
+    if tag_new_vendors(result.dataframe, tags):
+        save_vendor_tags(tags)
+    ensure_needs_wants(result, tags)
+
+    folder = Path(f"finance_report_{datetime.now():%Y%m%d_%H%M%S}")
+    render_reports(result, folder)
+
+    csv_path = folder / "full_enriched_dataset.csv"
+    result.dataframe.to_csv(csv_path, index=False)
+    if args.sqlite:
+        with sqlite3.connect("transactions.db") as connection:
+            result.dataframe.to_sql("tx", connection, if_exists="append", index=False)
+
+    today = pd.Timestamp.today().normalize()
+    df = result.dataframe
+    last7 = abs(df[(df.Datum >= today - timedelta(days=7)) & (df.Iznos < 0)]["Iznos"].sum())
+    prev7 = abs(
+        df[
+            (df.Datum >= today - timedelta(days=14))
+            & (df.Datum < today - timedelta(days=7))
+            & (df.Iznos < 0)
+        ]["Iznos"].sum()
+    )
+    delta = last7 - prev7
+    total_spend = df[df.Iznos < 0]["Iznos"].abs().sum()
+    vampires = (
+        df[df.Iznos < 0]
+        .groupby("VENDOR")["Iznos"]
+        .sum()
+        .abs()
+        .div(total_spend)
+        .loc[lambda series: series > 0.05]
+        .index.tolist()
+    )
+
+    summary = result.summary
+    net_12 = summary.projected_net[-1]
+    print(
+        f"\nMonths: {summary.months} | Avg save: {fmt(summary.avg_savings)} RSD"
+        f" | Net 12 mo: {fmt(net_12)} RSD ({fmt(net_12 / result.fx_rate)} €)"
+    )
+    print(f"Last 7-day spend: {fmt(last7)} RSD (Δ {fmt(delta)} vs prev 7 d)")
+    if vampires:
+        print("Consider cutting:", ", ".join(vampires))
+    print("Projected pure savings (12 mo):")
+    for idx, value in enumerate(summary.projected_savings, 1):
+        print(f"  +{idx:02d} mo → {fmt(value)} RSD ({fmt(value / result.fx_rate)} €)")
+    print("Charts + CSV saved →", folder)
+
+
+if __name__ == "__main__":
     main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+import matplotlib
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+matplotlib.use("Agg")

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from wallettaser import analytics
+
+
+def build_df():
+    df = pd.DataFrame(
+        {
+            "Datum": pd.to_datetime(["2024-01-01", "2024-01-15", "2024-01-20", "2024-02-10"]),
+            "Iznos": [1000.0, -200.0, 100.0, -50.0],
+            "CATEGORY": ["INCOME", "SPENDING", "SAVINGS", "STOCKS/CRYPTO"],
+        }
+    )
+    df["MONTH"] = df["Datum"].dt.to_period("M")
+    return df
+
+
+def test_project_savings():
+    assert analytics.project_savings(100.0, months=3) == [100.0, 200.0, 300.0]
+
+
+def test_summary_computes_averages():
+    df = build_df()
+    result = analytics.summary(df)
+    assert result.months == 2
+    assert result.avg_income == 500.0
+    assert result.avg_savings == 50.0
+    assert len(result.projected_net) == 13
+    assert len(result.projected_savings) == 12

--- a/tests/test_categorization.py
+++ b/tests/test_categorization.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from wallettaser import categorization
+
+
+def make_df():
+    return pd.DataFrame(
+        {
+            "Datum": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "Tip": ["Priliv", "Odliv"],
+            "Opis": ["Primanje", "Kupovina EUR"],
+            "Iznos": [1000.0, -200.0],
+        }
+    )
+
+
+def test_vendor_pattern_matching():
+    assert categorization.vendor("Shopping at Maxi store") == "MAXI"
+    assert categorization.vendor("Unknown 123") == "UNKNOWN"
+
+
+def test_apply_categories_adjusts_columns():
+    df = make_df()
+    categorised = categorization.apply_categories(df)
+    assert set(["CATEGORY", "VENDOR", "ADV_CAT"]).issubset(categorised.columns)
+    assert categorised.loc[categorised["Opis"] == "Primanje", "CATEGORY"].iloc[0] == "INCOME"
+    # Savings transactions must be positive
+    assert categorised.loc[categorised["Opis"] == "Kupovina EUR", "Iznos"].iloc[0] == 200.0
+
+
+def test_apply_needs_wants_uses_tags():
+    df = make_df()
+    categorised = categorization.apply_categories(df)
+    updated = categorization.apply_needs_wants(categorised, tags={"PRIMANJE": "NEEDS"})
+    assert set(updated["NEEDS_WANTS"]) == {"TRANSFER", "NEEDS"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pandas as pd
+
+import finance
+from wallettaser.analytics import Summary
+from wallettaser.facade import ProcessedStatement
+
+
+def test_cli_delegates_to_facade(monkeypatch, tmp_path):
+    data = pd.DataFrame(
+        {
+            "Datum": pd.to_datetime(["2024-01-01"]),
+            "Iznos": [-100.0],
+            "Tip": ["Odliv"],
+            "Opis": ["Store"],
+            "CATEGORY": ["SPENDING"],
+            "VENDOR": ["STORE"],
+            "ADV_CAT": ["OTHER"],
+            "MONTH": pd.PeriodIndex(["2024-01"], freq="M"),
+            "YEAR_MONTH": pd.PeriodIndex(["2024-01"], freq="M"),
+            "DAY": [0],
+            "HOUR": [12],
+            "NEEDS_WANTS": ["WANTS"],
+        }
+    )
+    summary = Summary(
+        months=1,
+        projected_net=[0.0, 10.0],
+        projected_savings=[10.0],
+        avg_savings=10.0,
+        avg_income=20.0,
+        avg_spend=-30.0,
+        avg_stocks=5.0,
+    )
+    processed = ProcessedStatement(dataframe=data.copy(), summary=summary, charts=[], fx_rate=100.0)
+
+    mock_process = mock.Mock(return_value=processed)
+    monkeypatch.setattr(finance, "process_statement", mock_process)
+    monkeypatch.setattr(finance, "load_vendor_tags", lambda: {})
+    monkeypatch.setattr(finance, "tag_new_vendors", lambda df, tags: False)
+
+    created_folders = []
+
+    def fake_render(result, folder):
+        folder_path = Path(folder)
+        folder_path.mkdir(parents=True, exist_ok=True)
+        created_folders.append(folder_path)
+
+    monkeypatch.setattr(finance, "render_reports", fake_render)
+
+    dummy_file = tmp_path / "statement.xlsx"
+    dummy_file.write_text("dummy")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["finance.py", "-f", str(dummy_file), "--fx", "100"])
+
+    finance.main()
+
+    assert mock_process.call_count == 1
+    _, kwargs = mock_process.call_args
+    assert kwargs["fx_rate"] == 100.0
+    assert created_folders, "render_reports should be invoked"
+    csv_files = list(created_folders[0].glob("full_enriched_dataset.csv"))
+    assert csv_files and csv_files[0].is_file()

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from wallettaser import facade
+
+
+def test_process_statement_with_dataframe():
+    df = pd.DataFrame(
+        {
+            "Datum": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "Tip": ["Priliv", "Odliv"],
+            "Opis": ["Salary", "Maxi purchase"],
+            "Iznos": [1000.0, -200.0],
+        }
+    )
+
+    result = facade.process_statement(df, fx_rate=120.0)
+    expected_columns = {"CATEGORY", "VENDOR", "ADV_CAT", "MONTH", "YEAR_MONTH", "DAY", "HOUR", "NEEDS_WANTS"}
+    assert expected_columns.issubset(result.dataframe.columns)
+    assert len(result.charts) == 10
+    assert result.summary.months == 1
+    assert result.fx_rate == 120.0

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+from wallettaser import ingestion
+
+
+def test_load_clean(monkeypatch):
+    raw = pd.DataFrame(
+        [
+            ["noise", "noise", "noise", "noise"],
+            ["Datum", "Tip", "Opis", "Iznos"],
+            ["2024", "2024", "2024", "2024"],
+        ]
+    )
+    cleaned = pd.DataFrame(
+        {
+            "Datum transakcije": ["01.01.2024", "02.01.2024"],
+            "Tip": ["Priliv", "Odliv"],
+            "Opis": ["Salary", "Maxi market"],
+            "Iznos": ["1.000,00", "-200,50"],
+        }
+    )
+
+    def fake_read_excel(path, header=None, dtype=None):
+        return raw if header is None else cleaned
+
+    monkeypatch.setattr(ingestion.pd, "read_excel", fake_read_excel)
+
+    df = ingestion.load_clean("dummy.xlsx")
+    assert list(df.columns) == ["Datum", "Tip", "Opis", "Iznos"]
+    assert len(df) == 2
+    assert df.loc[df["Opis"] == "Salary", "Iznos"].iloc[0] == 1000.0
+    assert df.loc[df["Opis"] == "Maxi market", "Iznos"].iloc[0] == -200.50
+    assert pd.api.types.is_datetime64_any_dtype(df["Datum"])  # dates parsed

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pandas as pd
+
+from wallettaser import analytics, reporting
+
+
+def build_dataframe():
+    dates = pd.date_range("2024-01-01", periods=48, freq="h")
+    df = pd.DataFrame(
+        {
+            "Datum": dates,
+            "Iznos": [-100.0 - idx for idx in range(len(dates))],
+            "Tip": ["Odliv"] * len(dates),
+            "Opis": ["Maxi"] * len(dates),
+            "CATEGORY": ["SPENDING"] * len(dates),
+            "VENDOR": ["MAXI"] * len(dates),
+            "ADV_CAT": ["FOOD"] * len(dates),
+            "MONTH": dates.to_period("M"),
+            "YEAR_MONTH": dates.to_period("M"),
+            "DAY": dates.dayofweek,
+            "HOUR": dates.hour,
+            "NEEDS_WANTS": ["WANTS"] * len(dates),
+        }
+    )
+    income_row = {
+        "Datum": pd.Timestamp("2024-01-05"),
+        "Iznos": 1000.0,
+        "Tip": "Priliv",
+        "Opis": "Salary",
+        "CATEGORY": "INCOME",
+        "VENDOR": "COMPANY",
+        "ADV_CAT": "INCOME",
+        "MONTH": pd.Timestamp("2024-01-05").to_period("M"),
+        "YEAR_MONTH": pd.Timestamp("2024-01-05").to_period("M"),
+        "DAY": pd.Timestamp("2024-01-05").dayofweek,
+        "HOUR": pd.Timestamp("2024-01-05").hour,
+        "NEEDS_WANTS": "WANTS",
+    }
+    df = pd.concat([df, pd.DataFrame([income_row])], ignore_index=True)
+    return df
+
+
+def test_chart_specs_render_all(tmp_path):
+    df = build_dataframe()
+    summary = analytics.summary(df)
+    specs = reporting.build_chart_specs(df, summary)
+    assert len(specs) == 10
+
+    output_dir = Path(tmp_path)
+    for spec in specs:
+        spec.render(output_dir, df, summary)
+
+    files = {path.name for path in output_dir.iterdir() if path.is_file()}
+    expected = {
+        "totals.png",
+        "vendors_top.png",
+        "weekday_spend.png",
+        "hourly_spend.png",
+        "monthly_trends.png",
+        "monthly_net.png",
+        "needs_wants.png",
+        "projected_net.png",
+        "projected_savings.png",
+    }
+    assert expected.issubset(files)
+    assert any(name.startswith("rolling") for name in files)

--- a/wallettaser/__init__.py
+++ b/wallettaser/__init__.py
@@ -1,0 +1,4 @@
+"""Wallet Taser core package."""
+from .facade import ProcessedStatement, process_statement
+
+__all__ = ["ProcessedStatement", "process_statement"]

--- a/wallettaser/analytics.py
+++ b/wallettaser/analytics.py
@@ -1,0 +1,53 @@
+"""Analytical helpers for Wallet Taser."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Summary:
+    months: int
+    projected_net: List[float]
+    projected_savings: List[float]
+    avg_savings: float
+    avg_income: float
+    avg_spend: float
+    avg_stocks: float
+
+
+def project_savings(avg_save: float, months: int = 12) -> List[float]:
+    """Return the cumulative savings projection for the given monthly average."""
+    return [round(avg_save * month, 2) for month in range(1, months + 1)]
+
+
+def summary(df: pd.DataFrame) -> Summary:
+    """Compute summary metrics for a categorised dataframe."""
+    months = df["MONTH"].nunique() or 1
+    selector = lambda category: df[df.CATEGORY == category]["Iznos"].sum()
+    income = selector("INCOME")
+    spend = selector("SPENDING")
+    savings = selector("SAVINGS")
+    stocks = abs(selector("STOCKS/CRYPTO"))
+
+    avg_income = income / months
+    avg_spend = spend / months
+    avg_savings = savings / months
+    avg_stocks = stocks / months
+
+    projected_net = [0.0]
+    for _ in range(12):
+        projected_net.append(projected_net[-1] + avg_income - abs(avg_spend) + avg_savings + avg_stocks)
+
+    projected_savings = project_savings(avg_savings, 12)
+    return Summary(
+        months=months,
+        projected_net=projected_net,
+        projected_savings=projected_savings,
+        avg_savings=avg_savings,
+        avg_income=avg_income,
+        avg_spend=avg_spend,
+        avg_stocks=avg_stocks,
+    )

--- a/wallettaser/categorization.py
+++ b/wallettaser/categorization.py
@@ -1,0 +1,110 @@
+"""Categorisation helpers for Wallet Taser."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping
+
+import pandas as pd
+
+
+PATTERNS: Dict[str, Iterable[str]] = {
+    "MAXI": ["maxi"],
+    "TIDAL": ["tidal"],
+    "CAR GO": ["car go", "cargo"],
+    "APOTEKA": ["apoteka"],
+    "LIDL": ["lidl"],
+    "EBAY": ["ebay"],
+    "ALIEXPRESS": ["aliexpress", "ali express", "ali"],
+    "GO TECH": ["go technologies"],
+    "PAYPAL": ["paypal"],
+    "WOLT": ["wolt"],
+    "DEXPRESS": ["dexpress"],
+}
+
+ADVANCED_PATTERNS: Dict[str, Iterable[str]] = {
+    "FOOD": ["lidl", "maxi", "idea", "tempo", "shop&go"],
+    "TRANSPORT": ["car go", "naxis", "busplus"],
+    "EDUCATION": ["udemy", "tryhackme", "coursera", "book"],
+    "MEDICAL": ["apoteka", "pharmacy", "dr"],
+    "ENTERTAINMENT": ["netflix", "tidal", "youtube", "spotify"],
+}
+
+
+@dataclass(frozen=True)
+class CategorisationConfig:
+    """Configuration used when assigning high level categories."""
+
+    advanced_patterns: Dict[str, Iterable[str]] | None = None
+
+
+def vendor(description: str) -> str:
+    """Infer the most likely vendor name from a transaction description."""
+    lowered = description.lower()
+    for name, keys in PATTERNS.items():
+        if any(keyword in lowered for keyword in keys):
+            return name
+    match = re.search(r"[A-Za-z]{4,}", description)
+    return match.group(0).upper() if match else "OTHER"
+
+
+def _base_cat(row: pd.Series) -> str:
+    """Assign the base category for a transaction."""
+    opis = row["Opis"].lower()
+    tip = row["Tip"].lower()
+    amount = row["Iznos"]
+
+    if "kupovina eur" in opis:
+        return "SAVINGS"
+    if any(word in opis for word in ("zarada", "prilivi")) or "uplata" in tip:
+        return "INCOME"
+    if any(word in opis for word in ("xtb", "binance", "bifinity", "bit")):
+        return "STOCKS/CRYPTO"
+    if any(word in opis for word in ("bankomat", "isplata gotovine")):
+        return "ATM_CASHOUT"
+    if amount > 0:
+        return "INCOME"
+    return "SPENDING"
+
+
+def _adv_cat(row: pd.Series, config: CategorisationConfig | None = None) -> str:
+    """Assign the advanced category for a transaction."""
+    patterns = (config.advanced_patterns if config and config.advanced_patterns else ADVANCED_PATTERNS)
+    lowered = row["Opis"].lower()
+    for category, keys in patterns.items():
+        if any(keyword in lowered for keyword in keys):
+            return category
+    return _base_cat(row)
+
+
+def apply_categories(df: pd.DataFrame, config: CategorisationConfig | None = None) -> pd.DataFrame:
+    """Return a dataframe with category columns populated."""
+    df = df.copy()
+    df["CATEGORY"] = df.apply(_base_cat, axis=1)
+    df.loc[df["CATEGORY"] == "SAVINGS", "Iznos"] = df.loc[df["CATEGORY"] == "SAVINGS", "Iznos"].abs()
+    df["VENDOR"] = df["Opis"].apply(vendor)
+    df["ADV_CAT"] = df.apply(_adv_cat, axis=1, config=config)
+    return df
+
+
+def needs_wants(row: pd.Series, tags: Mapping[str, str] | None = None) -> str:
+    """Classify a row into NEEDS/WANTS based on vendor tags."""
+
+    if row["CATEGORY"] in ("SAVINGS", "STOCKS/CRYPTO"):
+        return "TRANSFER"
+    lookup = tags or {}
+    return lookup.get(row["VENDOR"], "WANTS")
+
+
+def apply_needs_wants(
+    df: pd.DataFrame,
+    tags: Mapping[str, str] | None = None,
+    *,
+    inplace: bool = False,
+) -> pd.DataFrame:
+    """Assign NEEDS/WANTS classes to transactions."""
+
+    target = df if inplace else df.copy()
+    lookup = dict(tags or {})
+    target["NEEDS_WANTS"] = target.apply(needs_wants, axis=1, tags=lookup)
+    return target

--- a/wallettaser/facade.py
+++ b/wallettaser/facade.py
@@ -1,0 +1,48 @@
+"""High level facade for Wallet Taser processing."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from . import analytics, categorization, ingestion, reporting
+
+
+@dataclass
+class ProcessedStatement:
+    """Container returned by :func:`process_statement`."""
+
+    dataframe: pd.DataFrame
+    summary: analytics.Summary
+    charts: Sequence[reporting.ChartSpec]
+    fx_rate: float
+
+
+def _prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    enriched = df.copy()
+    enriched["MONTH"] = enriched["Datum"].dt.to_period("M")
+    enriched["YEAR_MONTH"] = enriched["MONTH"]
+    enriched["DAY"] = enriched["Datum"].dt.dayofweek
+    enriched["HOUR"] = enriched["Datum"].dt.hour
+    return enriched
+
+
+def process_statement(path_or_df, *, fx_rate: float) -> ProcessedStatement:
+    """Process a bank statement into analytics and chart specifications."""
+
+    if isinstance(path_or_df, (str, Path)):
+        df = ingestion.load_clean(path_or_df)
+    elif isinstance(path_or_df, pd.DataFrame):
+        df = path_or_df.copy()
+    else:  # pragma: no cover - defensive branch
+        raise TypeError("path_or_df must be a path or pandas DataFrame")
+
+    df = categorization.apply_categories(df)
+    df = _prepare_dataframe(df)
+    categorization.apply_needs_wants(df, tags=None, inplace=True)
+
+    summary = analytics.summary(df)
+    charts = reporting.build_chart_specs(df, summary)
+    return ProcessedStatement(dataframe=df, summary=summary, charts=charts, fx_rate=fx_rate)

--- a/wallettaser/ingestion.py
+++ b/wallettaser/ingestion.py
@@ -1,0 +1,62 @@
+"""Data ingestion helpers for Wallet Taser."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import pandas as pd
+
+
+StatementSource = Union[str, Path]
+
+
+def load_clean(path: StatementSource) -> pd.DataFrame:
+    """Load and standardise a bank statement spreadsheet.
+
+    Parameters
+    ----------
+    path:
+        Path to the spreadsheet containing a single statement. The header row
+        can appear anywhere within the first 30 rows of the file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A dataframe with canonicalised column names (``Datum``, ``Tip``,
+        ``Opis`` and ``Iznos``) and parsed date/amount values.
+    """
+
+    raw = pd.read_excel(path, header=None, dtype=str)
+    header_row = next(
+        idx
+        for idx in range(min(len(raw), 30))
+        if sum(
+            any(keyword in str(col).lower() for keyword in ("datum", "tip", "opis", "iznos"))
+            for col in raw.iloc[idx]
+        )
+        >= 3
+    )
+
+    df = pd.read_excel(path, header=header_row, dtype=str)
+    renames: dict[str, str] = {}
+    for column in df.columns:
+        lowered = str(column).lower()
+        if "datum" in lowered:
+            renames[column] = "Datum"
+        elif "tip" in lowered:
+            renames[column] = "Tip"
+        elif any(keyword in lowered for keyword in ("opis", "naziv", "det")):
+            renames[column] = "Opis"
+        elif any(keyword in lowered for keyword in ("iznos", "amount", "suma")):
+            renames[column] = "Iznos"
+
+    df = df.rename(columns=renames)[["Datum", "Tip", "Opis", "Iznos"]].dropna()
+    df["Datum"] = pd.to_datetime(df["Datum"], dayfirst=True, errors="coerce")
+    df = df[df["Datum"].notna()].copy()
+    df["Iznos"] = (
+        df["Iznos"].str.replace(r"[^0-9,.\\-]", "", regex=True)
+        .str.replace(".", "", regex=False)
+        .str.replace(",", ".", regex=False)
+        .astype(float)
+    )
+    return df

--- a/wallettaser/reporting.py
+++ b/wallettaser/reporting.py
@@ -1,0 +1,221 @@
+"""Reporting helpers for Wallet Taser."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from itertools import cycle
+from pathlib import Path
+from typing import Callable, Iterable, List
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from .analytics import Summary
+
+
+fmt = lambda value: f"{value:,.2f}"
+
+
+@dataclass
+class ChartSpec:
+    """Representation of a report chart."""
+
+    filename: str
+    renderer: Callable[[Path, pd.DataFrame, Summary], None]
+
+    def render(self, folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+        """Render the chart into ``folder`` using ``df`` and ``summary``."""
+        folder = Path(folder)
+        folder.mkdir(parents=True, exist_ok=True)
+        self.renderer(folder, df, summary)
+
+
+def safe(func: Callable[..., None]) -> Callable[..., None]:
+    """Decorator that logs rendering failures without aborting the run."""
+
+    def wrapper(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+        try:
+            func(folder, df, summary)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logging.warning("%s failed: %s", func.__name__, exc)
+
+    return wrapper
+
+
+@safe
+def plot_totals(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    labels = ["Spend", "Save", "Stocks", "Income"]
+    values = [abs(summary.avg_spend) * summary.months, summary.avg_savings * summary.months,
+              summary.avg_stocks * summary.months, summary.avg_income * summary.months]
+    plt.figure(figsize=(8, 4))
+    bars = plt.bar(labels, values, color=["#e74c3c", "#27ae60", "#8e44ad", "#3498db"])
+    for bar, value in zip(bars, values):
+        plt.text(bar.get_x() + bar.get_width() / 2, value, fmt(value), ha="center", va="bottom", fontsize=9)
+    plt.title("Totals by Category")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / "totals.png")
+    plt.close()
+
+
+TOP_COLORS = cycle(["#e74c3c", "#f1c40f", "#27ae60"])
+
+
+@safe
+def plot_vendors(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    top = (
+        df[df.Iznos < 0]
+        .groupby("VENDOR")["Iznos"]
+        .sum()
+        .abs()
+        .sort_values(ascending=False)
+        .head(10)
+    )
+    colors = [next(TOP_COLORS) if idx < 3 else "#2980b9" for idx in range(len(top))]
+    plt.figure(figsize=(10, 6))
+    bars = plt.bar(top.index, top.values, color=colors)
+    for bar, value in zip(bars, top.values):
+        plt.text(bar.get_x() + bar.get_width() / 2, value, fmt(value), ha="center", va="bottom", fontsize=9)
+    plt.title("Top Vendor Spend")
+    plt.ylabel("RSD")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig(folder / "vendors_top.png")
+    plt.close()
+
+
+@safe
+def plot_weekday(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    weekly = df[df.Iznos < 0].groupby("DAY")["Iznos"].sum()
+    plt.figure(figsize=(8, 4))
+    weekly.plot(kind="bar", color="#c0392b")
+    plt.title("Spending by Weekday")
+    plt.ylabel("RSD")
+    plt.xticks(range(7), ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"])
+    plt.tight_layout()
+    plt.savefig(folder / "weekday_spend.png")
+    plt.close()
+
+
+@safe
+def plot_hourly(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    hourly = df[df.Iznos < 0].groupby("HOUR")["Iznos"].sum()
+    if hourly.sum() == 0 or hourly.nunique() <= 1:
+        return
+    hourly = hourly.reindex(range(24), fill_value=0)
+    plt.figure(figsize=(14, 4))
+    hourly.plot(kind="bar", color="#9b59b6")
+    plt.grid(axis="y", alpha=0.3)
+    plt.title("Spending by Hour (0-23)")
+    plt.xlabel("Hour")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / "hourly_spend.png")
+    plt.close()
+
+
+@safe
+def plot_monthly_trends(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    monthly = df.groupby(["YEAR_MONTH", "ADV_CAT"])["Iznos"].sum().unstack().fillna(0)
+    monthly.plot(kind="bar", stacked=True, figsize=(12, 6))
+    plt.title("Monthly Cash-flow by Advanced Category")
+    plt.ylabel("RSD")
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig(folder / "monthly_trends.png")
+    plt.close()
+
+
+@safe
+def plot_rolling(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    daily = (
+        df[df.Iznos < 0]
+        .set_index("Datum")
+        .resample("D")["Iznos"]
+        .sum()
+        .abs()
+    )
+    window = 30 if len(daily) >= 30 else 7
+    daily.rolling(window).sum().plot(figsize=(12, 5))
+    plt.title(f"{window}-Day Rolling Spend")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / f"rolling{window}_spend.png")
+    plt.close()
+
+
+@safe
+def plot_monthly_net(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    net_monthly = df.groupby("YEAR_MONTH")["Iznos"].sum()
+    net_monthly.plot(marker="o", figsize=(10, 4))
+    plt.axhline(0, color="gray", ls="--")
+    plt.title("Monthly Net Δ")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / "monthly_net.png")
+    plt.close()
+
+
+@safe
+def plot_needs_wants(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    selection = (
+        df[(df.Iznos < 0) & (df.NEEDS_WANTS != "TRANSFER")]
+        .groupby("NEEDS_WANTS")["Iznos"]
+        .sum()
+        .abs()
+    )
+    selection = selection.reindex(["NEEDS", "WANTS"]).fillna(0)
+    plt.figure(figsize=(7, 5))
+    bars = plt.bar(selection.index, selection.values, color=["#2ecc71", "#e67e22"])
+    for bar, value in zip(bars, selection.values):
+        plt.text(bar.get_x() + bar.get_width() / 2, value, fmt(value), ha="center", va="bottom", fontsize=10)
+    plt.title("NEEDS vs WANTS")
+    plt.ylabel("RSD")
+    plt.tight_layout()
+    plt.savefig(folder / "needs_wants.png")
+    plt.close()
+
+
+@safe
+def plot_projected_net(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    xs = list(range(len(summary.projected_net)))
+    plt.figure(figsize=(10, 5))
+    plt.plot(xs, summary.projected_net, marker="o", color="#1abc9c")
+    plt.title("Projected Net Worth")
+    plt.xlabel("Months")
+    plt.ylabel("RSD")
+    plt.grid(alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(folder / "projected_net.png")
+    plt.close()
+
+
+@safe
+def plot_projected_savings(folder: Path, df: pd.DataFrame, summary: Summary) -> None:
+    xs = list(range(1, len(summary.projected_savings) + 1))
+    plt.figure(figsize=(10, 5))
+    plt.plot(xs, summary.projected_savings, marker="o", color="#e67e22")
+    plt.title("Projected Savings Only (12 mo)")
+    plt.xlabel("Months")
+    plt.ylabel("RSD")
+    plt.grid(alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(folder / "projected_savings.png")
+    plt.close()
+
+
+def build_chart_specs(df: pd.DataFrame, summary: Summary) -> List[ChartSpec]:
+    """Return the list of chart specs for the given dataset."""
+    renderers: Iterable[tuple[str, Callable[[Path, pd.DataFrame, Summary], None]]] = (
+        ("totals.png", plot_totals),
+        ("vendors_top.png", plot_vendors),
+        ("weekday_spend.png", plot_weekday),
+        ("hourly_spend.png", plot_hourly),
+        ("monthly_trends.png", plot_monthly_trends),
+        ("rolling_spend.png", plot_rolling),
+        ("monthly_net.png", plot_monthly_net),
+        ("needs_wants.png", plot_needs_wants),
+        ("projected_net.png", plot_projected_net),
+        ("projected_savings.png", plot_projected_savings),
+    )
+    return [ChartSpec(filename=name, renderer=renderer) for name, renderer in renderers]


### PR DESCRIPTION
## Summary
- create a dedicated `wallettaser` package with ingestion, categorisation, analytics, reporting and facade modules
- update the CLI to delegate to the new `process_statement` facade while keeping vendor tagging and report generation
- add pytest coverage for the new modules and CLI wrapper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa6b0fbf48325bde9ae9b7ef03910