### PR TITLE
Add SQLite vendor tag persistence and management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## 🔧 Features
 
 - Auto-detects export header rows from shitty Excel bank statements
-- Tags NEEDS vs WANTS using vendor memory (`vendor_tags.csv`)
+- Tags NEEDS vs WANTS using vendor memory persisted in SQLite
 - Regex-based vendor identification (LIDL, Car:Go, TIDAL, Binance, etc.)
 - Category classification: Income, Stocks, Savings, ATM, Spending
 - Auto-generates:
@@ -10,7 +10,8 @@
   - Daily, hourly, monthly, and rolling spend charts
   - NEEDS vs WANTS pie
   - 12-month net worth projection
-- CSV + SQLite export
+- CSV + SQLite export (transactions + vendor tags)
+- REST API + web UI for managing vendor tags per user
 - Console summary with vampire detection (parasitic vendors)
 
 ## 🐍 Requirements
@@ -21,5 +22,25 @@
 ## 🚀 Usage
 
 ```bash
-Obtain xls from your bank, put it in dir next to the script. Let it rip. 
-python3 finance.py -f bank.xlsx --fx 117.5 --sqlite --debug
+Obtain xls from your bank, put it in dir next to the script. Let it rip.
+python3 finance.py -f bank.xlsx --fx 117.5 --sqlite --user me@example.com
+```
+
+### 🗂 Vendor tag service
+
+Launch the Flask app to manage tags (defaults to port 5000):
+
+```bash
+pip install -r requirements.txt
+flask --app app run
+```
+
+Set `X-User-Id` header (or `?user_id=` query) to scope data per user.
+
+API examples:
+
+```bash
+curl -H "X-User-Id: me@example.com" http://localhost:5000/api/vendor-tags
+curl -X POST -H "Content-Type: application/json" -H "X-User-Id: me@example.com" \
+     -d '{"vendor":"LIDL","class":"NEEDS"}' http://localhost:5000/api/vendor-tags
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from flask import Flask, jsonify, redirect, render_template, request, url_for
+
+from persistence import TransactionReprocessor, VendorTagRepository
+
+app = Flask(__name__)
+
+repo = VendorTagRepository()
+repo.migrate_from_csv()
+reprocessor = TransactionReprocessor(repo)
+
+
+def resolve_user_id() -> str:
+    return (
+        request.headers.get('X-User-Id')
+        or request.args.get('user_id')
+        or request.form.get('user_id')
+        or 'default'
+    )
+
+
+@app.route('/')
+def index() -> str:
+    user_id = resolve_user_id()
+    tags = repo.list_tags(user_id)
+    return render_template('vendor_tags.html', tags=tags, user_id=user_id)
+
+
+@app.get('/api/vendor-tags')
+def list_vendor_tags() -> Any:
+    user_id = resolve_user_id()
+    return jsonify(repo.list_tags(user_id))
+
+
+def _parse_payload(data: Dict[str, Any]) -> Dict[str, str]:
+    vendor = (data.get('vendor') or '').upper().strip()
+    cls = (data.get('class') or '').upper().strip()
+    if cls not in {'NEEDS', 'WANTS'}:
+        raise ValueError('class must be NEEDS or WANTS')
+    if not vendor:
+        raise ValueError('vendor is required')
+    return {'vendor': vendor, 'class': cls}
+
+
+@app.post('/api/vendor-tags')
+def create_or_update_tag() -> Any:
+    user_id = resolve_user_id()
+    data = request.get_json(silent=True) or request.form.to_dict()
+    try:
+        payload = _parse_payload(data)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    repo.set_tag(user_id, payload['vendor'], payload['class'])
+    reprocessor.schedule(user_id, payload['vendor'])
+    return jsonify({'status': 'ok', 'vendor': payload['vendor'], 'class': payload['class']})
+
+
+@app.delete('/api/vendor-tags/<vendor>')
+def delete_tag(vendor: str) -> Any:
+    user_id = resolve_user_id()
+    vendor = vendor.upper()
+    repo.delete_tag(user_id, vendor)
+    reprocessor.schedule(user_id, vendor)
+    return jsonify({'status': 'ok', 'vendor': vendor})
+
+
+@app.post('/ui/vendor-tags')
+def ui_create_tag() -> Any:
+    response = create_or_update_tag()
+    if isinstance(response, tuple):
+        return response
+    user_id = resolve_user_id()
+    return redirect(url_for('index', user_id=user_id))
+
+
+@app.post('/ui/vendor-tags/<vendor>/delete')
+def ui_delete_tag(vendor: str) -> Any:
+    delete_tag(vendor)
+    user_id = resolve_user_id()
+    return redirect(url_for('index', user_id=user_id))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    app.run(debug=True)

--- a/persistence.py
+++ b/persistence.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import csv
+import logging
+import os
+import queue
+import sqlite3
+import threading
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+DB_PATH = 'wallettaser.db'
+TAG_CSV = 'vendor_tags.csv'
+
+
+class VendorTagRepository:
+    """Persistence helper for vendor tagging metadata."""
+
+    def __init__(self, db_path: str = DB_PATH) -> None:
+        self.db_path = db_path
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as con:
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS vendor_tags (
+                    user_id TEXT NOT NULL,
+                    vendor TEXT NOT NULL,
+                    class TEXT NOT NULL,
+                    PRIMARY KEY (user_id, vendor)
+                )
+                """
+            )
+
+    def migrate_from_csv(self, csv_path: str = TAG_CSV, user_id: str = 'default') -> None:
+        """Load legacy CSV tags into sqlite, keeping a backup of the file."""
+
+        if not os.path.exists(csv_path):
+            return
+
+        with open(csv_path, newline='') as fh:
+            reader = csv.DictReader(fh)
+            rows = [
+                (row.get('VENDOR', '').strip().upper(), row.get('CLASS', '').strip().upper())
+                for row in reader
+                if row.get('VENDOR')
+            ]
+
+        if not rows:
+            return
+
+        with self._connect() as con:
+            con.executemany(
+                "INSERT OR REPLACE INTO vendor_tags(user_id, vendor, class) VALUES (?, ?, ?)",
+                [(user_id, vendor, cls) for vendor, cls in rows],
+            )
+
+        backup_path = f"{csv_path}.bak"
+        try:
+            os.replace(csv_path, backup_path)
+            logging.info(
+                "Migrated %s vendor tags from %s to sqlite (backup saved to %s)",
+                len(rows),
+                csv_path,
+                backup_path,
+            )
+        except OSError:
+            logging.warning("Migrated vendor tags but failed to archive %s", csv_path)
+
+    def get_tags(self, user_id: str) -> Dict[str, str]:
+        with self._connect() as con:
+            cur = con.execute(
+                "SELECT vendor, class FROM vendor_tags WHERE user_id=?",
+                (user_id,),
+            )
+            return {vendor: cls for vendor, cls in cur.fetchall()}
+
+    def get_tag(self, user_id: str, vendor: str) -> Optional[str]:
+        with self._connect() as con:
+            cur = con.execute(
+                "SELECT class FROM vendor_tags WHERE user_id=? AND vendor=?",
+                (user_id, vendor),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def set_tag(self, user_id: str, vendor: str, cls: str) -> None:
+        with self._connect() as con:
+            con.execute(
+                "INSERT OR REPLACE INTO vendor_tags(user_id, vendor, class) VALUES (?, ?, ?)",
+                (user_id, vendor, cls),
+            )
+
+    def delete_tag(self, user_id: str, vendor: str) -> None:
+        with self._connect() as con:
+            con.execute(
+                "DELETE FROM vendor_tags WHERE user_id=? AND vendor=?",
+                (user_id, vendor),
+            )
+
+    def list_tags(self, user_id: str) -> list[dict[str, str]]:
+        with self._connect() as con:
+            cur = con.execute(
+                "SELECT vendor, class FROM vendor_tags WHERE user_id=? ORDER BY vendor",
+                (user_id,),
+            )
+            return [
+                {"vendor": vendor, "class": cls}
+                for vendor, cls in cur.fetchall()
+            ]
+
+
+def apply_tagging_decisions(
+    df,
+    repo: VendorTagRepository,
+    user_id: str,
+    decisions: Optional[Dict[str, str]] = None,
+    default_class: str = 'WANTS',
+    min_frequency: int = 3,
+) -> Dict[str, str]:
+    """Update vendor tags based on provided decisions.
+
+    Vendors that appear more frequently than ``min_frequency`` without a stored tag
+    receive ``default_class``. Decisions override stored values and are persisted.
+    Returns the effective tag map for ``user_id``.
+    """
+
+    decisions = {
+        (vendor or '').upper(): (cls or '').upper()
+        for vendor, cls in (decisions or {}).items()
+        if vendor
+    }
+
+    existing = repo.get_tags(user_id)
+
+    vendor_counts = df['VENDOR'].value_counts()
+    candidate_vendors = vendor_counts.loc[lambda s: s >= min_frequency].index.tolist()
+
+    for vendor in candidate_vendors:
+        if vendor in existing:
+            continue
+        choice = decisions.get(vendor, default_class)
+        if choice not in ('NEEDS', 'WANTS'):
+            choice = default_class
+        repo.set_tag(user_id, vendor, choice)
+        existing[vendor] = choice
+
+    for vendor, choice in decisions.items():
+        if choice not in ('NEEDS', 'WANTS'):
+            continue
+        if existing.get(vendor) == choice:
+            continue
+        repo.set_tag(user_id, vendor, choice)
+        existing[vendor] = choice
+
+    return existing
+
+
+@dataclass
+class ReprocessJob:
+    user_id: str
+    vendor: str
+
+
+class TransactionReprocessor:
+    """Background worker that updates stored transactions when tags change."""
+
+    def __init__(self, repo: VendorTagRepository, db_path: str = DB_PATH) -> None:
+        self.repo = repo
+        self.db_path = db_path
+        self._jobs: "queue.Queue[ReprocessJob]" = queue.Queue()
+        self._thread = threading.Thread(target=self._worker, daemon=True)
+        self._thread.start()
+
+    def schedule(self, user_id: str, vendor: str) -> None:
+        self._jobs.put(ReprocessJob(user_id=user_id, vendor=vendor))
+
+    def _worker(self) -> None:
+        while True:
+            job = self._jobs.get()
+            try:
+                self._apply(job)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logging.exception("Failed to reprocess %s/%s: %s", job.user_id, job.vendor, exc)
+            finally:
+                self._jobs.task_done()
+
+    def _apply(self, job: ReprocessJob) -> None:
+        with sqlite3.connect(self.db_path) as con:
+            cur = con.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                ('transactions',),
+            )
+            if not cur.fetchone():
+                return
+
+            tag = self.repo.get_tag(job.user_id, job.vendor) or 'WANTS'
+            con.execute(
+                "UPDATE transactions SET NEEDS_WANTS=? WHERE USER_ID=? AND VENDOR=?",
+                (tag, job.user_id, job.vendor),
+            )
+            con.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 matplotlib
 xlrd
+Flask

--- a/templates/vendor_tags.html
+++ b/templates/vendor_tags.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Vendor Tags</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; background: #f7f9fb; color: #2c3e50; }
+    h1 { margin-bottom: 0.5rem; }
+    .actions { margin-bottom: 1.5rem; }
+    form { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+    input, select, button { padding: 0.5rem; font-size: 1rem; }
+    table { width: 100%; border-collapse: collapse; background: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+    th, td { padding: 0.75rem; border-bottom: 1px solid #ecf0f1; text-align: left; }
+    tr:nth-child(even) { background: #f2f6f9; }
+    .tag-actions { display: flex; gap: 0.5rem; }
+    .danger { background: #e74c3c; color: #fff; border: none; cursor: pointer; }
+    .primary { background: #3498db; color: #fff; border: none; cursor: pointer; }
+    .message { margin-top: 1rem; color: #e67e22; }
+    @media (max-width: 600px) {
+      table, thead, tbody, th, td, tr { display: block; }
+      th { display: none; }
+      tr { margin-bottom: 1rem; }
+      td { border: none; position: relative; padding-left: 50%; }
+      td::before { content: attr(data-label); position: absolute; left: 0; width: 45%; padding-left: 1rem; font-weight: bold; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Vendor Tags for {{ user_id }}</h1>
+  <div class="actions">
+    <form id="tag-form" method="post" action="/ui/vendor-tags">
+      <input type="hidden" name="user_id" value="{{ user_id }}">
+      <label>
+        Vendor
+        <input name="vendor" placeholder="e.g. LIDL" required>
+      </label>
+      <label>
+        Class
+        <select name="class">
+          <option value="NEEDS">NEEDS</option>
+          <option value="WANTS">WANTS</option>
+        </select>
+      </label>
+      <button class="primary" type="submit">Save</button>
+    </form>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Vendor</th>
+        <th>Class</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for tag in tags %}
+      <tr>
+        <td data-label="Vendor">{{ tag.vendor }}</td>
+        <td data-label="Class">{{ tag.class }}</td>
+        <td data-label="Actions">
+          <form class="tag-actions" method="post" action="/ui/vendor-tags/{{ tag.vendor }}/delete">
+            <input type="hidden" name="user_id" value="{{ user_id }}">
+            <button class="danger" type="submit">Delete</button>
+          </form>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="3">No tags yet. Add one above!</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace CSV-based vendor tags with a SQLite repository and CLI integration, including CSV migration helpers
- add a Flask API + HTML UI for per-user vendor tag management with background transaction reprocessing
- document the new workflow and dependencies for managing tags and reports

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68caa6b652e88325920230e8ca19bf8b